### PR TITLE
only error message logging for non-debug builds

### DIFF
--- a/make.py
+++ b/make.py
@@ -9,7 +9,9 @@ import platform
 bin_dir = 'bin'
 build_dir = 'build'
 only_cmake = False
+build_debug = False
 cmake = 'cmake'
+make = 'make'
 
 if len(sys.argv) >= 2:
     if sys.argv[1] == '-h':
@@ -19,7 +21,9 @@ if len(sys.argv) >= 2:
         os.system('git clean -dfx')
         quit()
     if sys.argv[1] == 'debug':
+        build_debug = True
         cmake = cmake + ' -DCMAKE_BUILD_TYPE=Debug'
+        make = make + ' VERBOSE=1'
     elif sys.argv[1] == 'only-cmake':
 #        cmake = cmake + ' -DTRACE_SILENT_MODE'
         only_cmake = True
@@ -41,9 +45,13 @@ sys_name = platform.system()
 
 if sys_name == 'Linux' or sys_name == 'Darwin':
     print('\nMaking for Linux...\n')
+    if build_debug:
+        print('Building for Debug...\n')
+    else:
+        print('Building for Release...\n')
     command = 'cd build && ' + cmake + ' .. && echo'
     if os.system(command) == 0:
-        command = 'cd build && make'
+        command = 'cd build && ' + make
         if not only_cmake:
             os.system(command)
 

--- a/src/util/trace.h
+++ b/src/util/trace.h
@@ -69,6 +69,8 @@ namespace p2psp
 
 #ifndef TRACE_SILENT_MODE
 
+#ifndef NDEBUG
+
 #define LOG(a)      \
   { BOOST_LOG_SEV(p2psp::TraceSystem::logger(), boost::log::trivial::info) \
     << a; }
@@ -86,6 +88,20 @@ namespace p2psp
   { BOOST_LOG_SEV(p2psp::TraceSystem::logger(), boost::log::trivial::trace)  \
     << _SET_COLOR(_YELLOW) << __FILE__ << ":" << __LINE__ << ": TRACE: " \
     << a << _RESET_COLOR(); }
+
+#else
+
+#define LOG(a)      {}
+#define LOGC(c, a)  {}
+
+#define ERROR(a)    \
+  { BOOST_LOG_SEV(p2psp::TraceSystem::logger(), boost::log::trivial::error)  \
+    << _SET_COLOR(_RED) << __FILE__ << ":" << __LINE__ << ": ERROR: " \
+    << a << _RESET_COLOR(); }
+
+#define TRACE(a)    {}
+
+#endif // NDEBUG
     
 #else
 


### PR DESCRIPTION
made some changes to the tracing module so that in non-debug builds only
error messages will be logged.
modified `make.py` to show which mode (build or release) is being build
for.
while building in debug mode make commands verbosity option is set. so,
that it is easier to figure out which compiler flags are being passed.