### PR TITLE
Indentation by spaces, no trailing whitespace

### DIFF
--- a/src/core/common.h
+++ b/src/core/common.h
@@ -17,9 +17,9 @@
 namespace p2psp {
 
   class Common {
-    
+
   public:
-    
+
     static const int kMaxChunkNumber = 65536;
     // MAX_CHUNK_NUMBER = 2048
     // COUNTERS_TIMING = 0.1
@@ -55,7 +55,7 @@ namespace p2psp {
 
     static void sha256(std::vector<char> string, std::vector<char> &digest) {
       SHA256((unsigned char *)string.data(), string.size(),
-	     (unsigned char *)digest.data());
+             (unsigned char *)digest.data());
     }
   };
 }

--- a/src/core/peer_dbs.cc
+++ b/src/core/peer_dbs.cc
@@ -29,8 +29,8 @@ namespace p2psp {
     team_socket_.send_to(buffer(hello), node);
 
     TRACE("[Hello] sent to "
-	  << "(" << node.address().to_string() << ","
-	  << std::to_string(node.port()) << ")");
+          << "(" << node.address().to_string() << ","
+          << std::to_string(node.port()) << ")");
   }
 
   void PeerDBS::SayGoodbye(const ip::udp::endpoint &node) {
@@ -39,8 +39,8 @@ namespace p2psp {
     team_socket_.send_to(buffer(goodbye), node);
 
     TRACE("[Goodbye] sent to "
-	  << "(" << node.address().to_string() << ","
-	  << std::to_string(node.port()) << ")");
+          << "(" << node.address().to_string() << ","
+          << std::to_string(node.port()) << ")");
   }
 
   void PeerDBS::ReceiveMagicFlags() {
@@ -54,8 +54,8 @@ namespace p2psp {
 
     // sys.stdout.write(Color.green)
     TRACE("Requesting the number of monitors and peers to ("
-	  << splitter_socket_.remote_endpoint().address().to_string() << ","
-	  << std::to_string(splitter_socket_.remote_endpoint().port()) << ")");
+          << splitter_socket_.remote_endpoint().address().to_string() << ","
+          << std::to_string(splitter_socket_.remote_endpoint().port()) << ")");
     read(splitter_socket_, ::buffer(buffer));
     number_of_monitors_ = ntohs(*(short *)(buffer.c_array()));
     TRACE("The number of monitors is " << number_of_monitors_);
@@ -73,10 +73,10 @@ namespace p2psp {
 
     // sys.stdout.write(Color.green)
     TRACE("Requesting" << number_of_peers_ << " peers to ("
-	  << splitter_socket_.remote_endpoint().address().to_string()
-	  << "," << std::to_string(
+          << splitter_socket_.remote_endpoint().address().to_string()
+          << "," << std::to_string(
                                    splitter_socket_.remote_endpoint().port())
-	  << ")");
+          << ")");
     // number_of_peers =
     // socket.ntohs(struct.unpack("H",self.splitter_socket.recv(struct.calcsize("H")))[0])
     //_print_("The size of the team is", number_of_peers, "(apart from me)")
@@ -90,7 +90,7 @@ namespace p2psp {
 
       peer = ip::udp::endpoint(ip_addr, port);
       TRACE("[hello] sent to (" << peer.address().to_string() << ","
-	    << std::to_string(peer.port()) << ")");
+            << std::to_string(peer.port()) << ")");
       SayHello(peer);
 
       TRACE(std::to_string((number_of_peers_ - tmp) / number_of_peers_));
@@ -119,12 +119,12 @@ namespace p2psp {
     me_ = ip::udp::endpoint(ip_addr, port);
 
     TRACE("me = (" << me_.address().to_string() << ","
-	  << std::to_string(me_.port()) << ")");
+          << std::to_string(me_.port()) << ")");
   }
 
   void PeerDBS::ListenToTheTeam() {
     ip::udp::endpoint endpoint(ip::address_v4::any(),
-			       splitter_socket_.local_endpoint().port());
+                               splitter_socket_.local_endpoint().port());
 
     team_socket_.open(endpoint.protocol());
     team_socket_.set_option(ip::udp::socket::reuse_address(true));
@@ -136,7 +136,7 @@ namespace p2psp {
   }
 
   int PeerDBS::ProcessMessage(const std::vector<char> &message,
-			      const ip::udp::endpoint &sender) {
+                              const ip::udp::endpoint &sender) {
     // Now, receive and send.
 
     // TODO: remove hardcoded values
@@ -155,70 +155,70 @@ namespace p2psp {
       received_counter_++;
 
       if (sender == splitter_) {
-	// Send the previous chunk in burst sending
-	// mode if the chunk has not been sent to all
-	// the peers of the list of peers.
+        // Send the previous chunk in burst sending
+        // mode if the chunk has not been sent to all
+        // the peers of the list of peers.
 
-	TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
-	      << std::to_string(team_socket_.local_endpoint().port()) << ")"
-	      << "<-" << std::to_string(chunk_number) << "-"
-	      << "(" << sender.address().to_string() << ","
-	      << std::to_string(sender.port()) << ")");
-	// No aqui. Tal vez, DIS
+        TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
+              << std::to_string(team_socket_.local_endpoint().port()) << ")"
+              << "<-" << std::to_string(chunk_number) << "-"
+              << "(" << sender.address().to_string() << ","
+              << std::to_string(sender.port()) << ")");
+        // No aqui. Tal vez, DIS
 
-	if (kLogging) {
-	  LogMessage("buffer correctnes " +
-		     std::to_string(CalcBufferCorrectness()));
-	  LogMessage("buffer filling " + std::to_string(CalcBufferFilling()));
-	}
+        if (kLogging) {
+          LogMessage("buffer correctnes " +
+                     std::to_string(CalcBufferCorrectness()));
+          LogMessage("buffer filling " + std::to_string(CalcBufferFilling()));
+        }
 
-	while (receive_and_feed_counter_ < (int)peer_list_.size() &&
-	       receive_and_feed_counter_ > 0) {
-	  peer = peer_list_[receive_and_feed_counter_];
-	  team_socket_.send_to(::buffer(receive_and_feed_previous_), peer);
-	  sendto_counter_++;
+        while (receive_and_feed_counter_ < (int)peer_list_.size() &&
+               receive_and_feed_counter_ > 0) {
+          peer = peer_list_[receive_and_feed_counter_];
+          team_socket_.send_to(::buffer(receive_and_feed_previous_), peer);
+          sendto_counter_++;
 
-	  TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
-		<< std::to_string(team_socket_.local_endpoint().port()) << ")"
-		<< "-" << std::to_string(ntohs(receive_and_feed_previous_[0]))
-		<< "->"
-		<< "(" << peer.address().to_string() << ","
-		<< std::to_string(peer.port()) << ")");
+          TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
+                << std::to_string(team_socket_.local_endpoint().port()) << ")"
+                << "-" << std::to_string(ntohs(receive_and_feed_previous_[0]))
+                << "->"
+                << "(" << peer.address().to_string() << ","
+                << std::to_string(peer.port()) << ")");
 
-	  debt_[peer]++;
+          debt_[peer]++;
 
-	  if (debt_[peer] > kMaxChunkDebt) {
-	    TRACE("(" << peer.address().to_string() << ","
-		  << std::to_string(peer.port()) << ")"
-		  << " removed by unsupportive (" +
-		  std::to_string(debt_[peer]) + " lossess)");
-	    debt_.erase(peer);
-	    peer_list_.erase(
-			     std::find(peer_list_.begin(), peer_list_.end(), peer));
-	  }
+          if (debt_[peer] > kMaxChunkDebt) {
+            TRACE("(" << peer.address().to_string() << ","
+                  << std::to_string(peer.port()) << ")"
+                  << " removed by unsupportive (" +
+                  std::to_string(debt_[peer]) + " lossess)");
+            debt_.erase(peer);
+            peer_list_.erase(
+                             std::find(peer_list_.begin(), peer_list_.end(), peer));
+          }
 
-	  receive_and_feed_counter_++;
-	}
+          receive_and_feed_counter_++;
+        }
 
-	receive_and_feed_counter_ = 0;
-	receive_and_feed_previous_ = message;
+        receive_and_feed_counter_ = 0;
+        receive_and_feed_previous_ = message;
       } else {
-	TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
-	      << std::to_string(team_socket_.local_endpoint().port()) << ")"
-	      << "<-" << std::to_string(chunk_number) << "-"
-	      << "(" << sender.address().to_string() << ","
-	      << std::to_string(sender.port()) << ")");
+        TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
+              << std::to_string(team_socket_.local_endpoint().port()) << ")"
+              << "<-" << std::to_string(chunk_number) << "-"
+              << "(" << sender.address().to_string() << ","
+              << std::to_string(sender.port()) << ")");
 
-	if (peer_list_.end() ==
-	    std::find(peer_list_.begin(), peer_list_.end(), sender)) {
-	  peer_list_.push_back(sender);
-	  debt_[sender] = 0;
-	  TRACE("(" << sender.address().to_string() << ","
-		<< std::to_string(sender.port()) << ")"
-		<< " added by chunk " << std::to_string(chunk_number));
-	} else {
-	  debt_[sender]--;
-	}
+        if (peer_list_.end() ==
+            std::find(peer_list_.begin(), peer_list_.end(), sender)) {
+          peer_list_.push_back(sender);
+          debt_[sender] = 0;
+          TRACE("(" << sender.address().to_string() << ","
+                << std::to_string(sender.port()) << ")"
+                << " added by chunk " << std::to_string(chunk_number));
+        } else {
+          debt_[sender]--;
+        }
       }
 
       // A new chunk has arrived and the previous must be forwarded to next peer
@@ -228,32 +228,32 @@ namespace p2psp {
       std::vector<char> empty(1024, 0);
 
       if (receive_and_feed_counter_ < (int)peer_list_.size() &&
-	  !receive_and_feed_previous_.empty()) {
-	// Send the previous chunk in congestion avoiding mode.
+          !receive_and_feed_previous_.empty()) {
+        // Send the previous chunk in congestion avoiding mode.
 
-	peer = peer_list_[receive_and_feed_counter_];
-	team_socket_.send_to(::buffer(receive_and_feed_previous_), peer);
-	sendto_counter_++;
+        peer = peer_list_[receive_and_feed_counter_];
+        team_socket_.send_to(::buffer(receive_and_feed_previous_), peer);
+        sendto_counter_++;
 
-	debt_[peer]++;
+        debt_[peer]++;
 
-	if (debt_[peer] > kMaxChunkDebt) {
-	  TRACE("(" << peer.address().to_string() << ","
-		<< std::to_string(peer.port()) << ")"
-		<< " removed by unsupportive (" +
-		std::to_string(debt_[peer]) + " lossess)");
-	  debt_.erase(peer);
-	  peer_list_.erase(std::find(peer_list_.begin(), peer_list_.end(), peer));
-	}
+        if (debt_[peer] > kMaxChunkDebt) {
+          TRACE("(" << peer.address().to_string() << ","
+                << std::to_string(peer.port()) << ")"
+                << " removed by unsupportive (" +
+                std::to_string(debt_[peer]) + " lossess)");
+          debt_.erase(peer);
+          peer_list_.erase(std::find(peer_list_.begin(), peer_list_.end(), peer));
+        }
 
-	TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
-	      << std::to_string(team_socket_.local_endpoint().port()) << ")"
-	      << "-" << std::to_string(ntohs(receive_and_feed_previous_[0]))
-	      << "->"
-	      << "(" << peer.address().to_string() << ","
-	      << std::to_string(peer.port()) << ")");
+        TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
+              << std::to_string(team_socket_.local_endpoint().port()) << ")"
+              << "-" << std::to_string(ntohs(receive_and_feed_previous_[0]))
+              << "->"
+              << "(" << peer.address().to_string() << ","
+              << std::to_string(peer.port()) << ")");
 
-	receive_and_feed_counter_++;
+        receive_and_feed_counter_++;
       }
 
       return chunk_number;
@@ -263,32 +263,32 @@ namespace p2psp {
       TRACE("Control message received");
 
       if (message[0] == 'H') {
-	if (peer_list_.end() ==
-	    std::find(peer_list_.begin(), peer_list_.end(), sender)) {
-	  // The peer is new
-	  peer_list_.push_back(sender);
-	  debt_[sender] = 0;
-	  TRACE("(" << sender.address().to_string() << ","
-		<< std::to_string(sender.port()) << ")"
-		<< " added by [hello] ");
-	} else {
-	  if (peer_list_.end() !=
-	      std::find(peer_list_.begin(), peer_list_.end(), sender)) {
-	    // sys.stdout.write(Color.red)
-	    TRACE("(" << team_socket_.local_endpoint().address().to_string()
-		  << ","
-		  << std::to_string(team_socket_.local_endpoint().port())
-		  << ") \b: received \"goodbye\" from ("
-		  << sender.address().to_string() << ","
-		  << std::to_string(sender.port()) << ")");
-	    // sys.stdout.write(Color.none)
-	    peer_list_.erase(
-			     std::find(peer_list_.begin(), peer_list_.end(), sender));
-	    debt_.erase(sender);
-	  }
-	}
+        if (peer_list_.end() ==
+            std::find(peer_list_.begin(), peer_list_.end(), sender)) {
+          // The peer is new
+          peer_list_.push_back(sender);
+          debt_[sender] = 0;
+          TRACE("(" << sender.address().to_string() << ","
+                << std::to_string(sender.port()) << ")"
+                << " added by [hello] ");
+        } else {
+          if (peer_list_.end() !=
+              std::find(peer_list_.begin(), peer_list_.end(), sender)) {
+            // sys.stdout.write(Color.red)
+            TRACE("(" << team_socket_.local_endpoint().address().to_string()
+                  << ","
+                  << std::to_string(team_socket_.local_endpoint().port())
+                  << ") \b: received \"goodbye\" from ("
+                  << sender.address().to_string() << ","
+                  << std::to_string(sender.port()) << ")");
+            // sys.stdout.write(Color.none)
+            peer_list_.erase(
+                             std::find(peer_list_.begin(), peer_list_.end(), sender));
+            debt_.erase(sender);
+          }
+        }
 
-	return -1;
+        return -1;
       }
     }
 
@@ -311,13 +311,13 @@ namespace p2psp {
     int badchunks = 0;
 
     for (std::vector<Chunk>::iterator it = chunks_.begin(); it != chunks_.end();
-	 ++it) {
+         ++it) {
       if (it->received) {
-	if (it->data == zerochunk) {
-	  badchunks++;
-	} else {
-	  goodchunks++;
-	}
+        if (it->data == zerochunk) {
+          badchunks++;
+        } else {
+          goodchunks++;
+        }
       }
     }
 
@@ -328,9 +328,9 @@ namespace p2psp {
     int chunks = 0;
 
     for (std::vector<Chunk>::iterator it = chunks_.begin(); it != chunks_.end();
-	 ++it) {
+         ++it) {
       if (it->received) {
-	chunks++;
+        chunks++;
       }
     }
 
@@ -346,7 +346,7 @@ namespace p2psp {
     }
 
     for (std::vector<ip::udp::endpoint>::iterator it = peer_list_.begin();
-	 it != peer_list_.end(); ++it) {
+         it != peer_list_.end(); ++it) {
       SayGoodbye(*it);
     }
   }

--- a/src/core/peer_dbs.h
+++ b/src/core/peer_dbs.h
@@ -64,7 +64,7 @@ namespace p2psp {
     virtual void ReceiveMyEndpoint();
     virtual void ListenToTheTeam() override;
     virtual int ProcessMessage(const std::vector<char>&,
-			       const ip::udp::endpoint&) override;
+                               const ip::udp::endpoint&) override;
     virtual void LogMessage(const std::string&);
     virtual void BuildLogMessage(const std::string&);
     virtual float CalcBufferCorrectness();
@@ -78,7 +78,7 @@ namespace p2psp {
     virtual int GetNumberOfPeers();
     virtual void SetMaxChunkDebt(int);
     virtual int GetMaxChunkDebt();
-  
+
   };
 }
 

--- a/src/core/peer_ims.cc
+++ b/src/core/peer_ims.cc
@@ -73,13 +73,13 @@ namespace p2psp {
     acceptor_.listen();
 
     TRACE("Waiting for the player at (" << endpoint.address().to_string() << ","
-	  << std::to_string(endpoint.port())
-	  << ")");
+          << std::to_string(endpoint.port())
+          << ")");
     acceptor_.accept(player_socket_);
 
     TRACE("The player is ("
-	  << player_socket_.remote_endpoint().address().to_string() << ","
-	  << std::to_string(player_socket_.remote_endpoint().port()) << ")");
+          << player_socket_.remote_endpoint().address().to_string() << ","
+          << std::to_string(player_socket_.remote_endpoint().port()) << ")");
 #endif
   }
 
@@ -99,9 +99,9 @@ namespace p2psp {
     } else {
       ip::udp::socket s(io_service_);
       try {
-	s.connect(splitter_);
+        s.connect(splitter_);
       } catch (boost::system::system_error e) {
-	ERROR(e.what());
+        ERROR(e.what());
       }
 
       my_ip = s.local_endpoint().address().to_string();
@@ -111,8 +111,8 @@ namespace p2psp {
     splitter_socket_.open(splitter_tcp_endpoint.protocol());
 
     TRACE("Connecting to the splitter at ("
-	  << splitter_tcp_endpoint.address().to_string() << ","
-	  << std::to_string(splitter_tcp_endpoint.port()) << ") from " << my_ip);
+          << splitter_tcp_endpoint.address().to_string() << ","
+          << std::to_string(splitter_tcp_endpoint.port()) << ") from " << my_ip);
     if (team_port_ != 0) {
       TRACE("I'm using port" << std::to_string(team_port_));
       tcp_endpoint = ip::tcp::endpoint(ip::address::from_string(my_ip), team_port_);
@@ -127,8 +127,8 @@ namespace p2psp {
     splitter_socket_.connect(splitter_tcp_endpoint);
 
     TRACE("Connected to the splitter at ("
-	  << splitter_tcp_endpoint.address().to_string() << ","
-	  << std::to_string(splitter_tcp_endpoint.port()) << ")");
+          << splitter_tcp_endpoint.address().to_string() << ","
+          << std::to_string(splitter_tcp_endpoint.port()) << ")");
   }
 
   void PeerIMS::DisconnectFromTheSplitter() { splitter_socket_.close(); }
@@ -144,7 +144,7 @@ namespace p2psp {
     mcast_port_ = ntohs(*(short *)(raw_data + 4));
 
     TRACE("mcast_endpoint = (" << mcast_addr_.to_string() << ","
-	  << std::to_string(mcast_port_) << ")");
+          << std::to_string(mcast_port_) << ")");
   }
 
   void PeerIMS::ReceiveTheHeaderSize() {
@@ -162,7 +162,7 @@ namespace p2psp {
 
     chunk_size_ = ntohs(*(short *)(buffer.c_array()));
     message_size_=kChunkIndexSize+chunk_size_;
-  
+
     TRACE("chunk_size (bytes) = " << std::to_string(chunk_size_));
   }
 
@@ -188,7 +188,7 @@ namespace p2psp {
     }
 
     TRACE("Received " << std::to_string(header_size_in_bytes)
-	  << "bytes of header");
+          << "bytes of header");
   }
 
   void PeerIMS::ReceiveTheBufferSize() {
@@ -210,8 +210,8 @@ namespace p2psp {
     team_socket_.set_option(ip::multicast::join_group(mcast_addr_));
 
     TRACE("Listening to the mcast_channel = (" << mcast_addr_.to_string() << ","
-	  << std::to_string(mcast_port_)
-	  << ")");
+          << std::to_string(mcast_port_)
+          << ")");
   }
 
   void PeerIMS::BufferData() {
@@ -253,8 +253,8 @@ namespace p2psp {
     // of the circular queue.
 
     TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
-	  << std::to_string(team_socket_.local_endpoint().port()) << ")"
-	  << "\b: buffering = 000.00%");
+          << std::to_string(team_socket_.local_endpoint().port()) << ")"
+          << "\b: buffering = 000.00%");
     TraceSystem::Flush();
 
     // First chunk to be sent to the player.  The
@@ -270,8 +270,8 @@ namespace p2psp {
     played_chunk_ = chunk_number;
     TRACE("First chunk to play " << std::to_string(played_chunk_));
     TRACE("(" << team_socket_.local_endpoint().address().to_string() << ","
-	  << std::to_string(team_socket_.local_endpoint().port()) << ")"
-	  << "\b: buffering (\b" << std::to_string(100.0 / buffer_size_));
+          << std::to_string(team_socket_.local_endpoint().port()) << ")"
+          << "\b: buffering (\b" << std::to_string(100.0 / buffer_size_));
     // TODO: Justify: .rjust(4)
 
     // Now, fill up to the half of the buffer.
@@ -283,21 +283,21 @@ namespace p2psp {
       // BUFFER_STATUS = (100 * x) / (buffer_size_ / 2.0f) + 1;
 
       if (!Common::kConsoleMode) {
-	// GObject.idle_add(buffering_adapter.update_widget,BUFFER_STATUS)
+        // GObject.idle_add(buffering_adapter.update_widget,BUFFER_STATUS)
       } else {
-	// pass
+        // pass
       }
       TRACE("!");
       TraceSystem::Flush();
 
       while (ProcessNextMessage() < 0)
-	;
+        ;
     }
 
     TRACE("");
     TRACE("latency = " << std::to_string((clock() - start_time) /
-					 (float)CLOCKS_PER_SEC)
-	  << " seconds");
+                                         (float)CLOCKS_PER_SEC)
+          << " seconds");
     TRACE("buffering done.");
     TraceSystem::Flush();
   }
@@ -317,18 +317,18 @@ namespace p2psp {
   }
 
   void PeerIMS::ReceiveTheNextMessage(std::vector<char> &message,
-				      ip::udp::endpoint &sender) {
+                                      ip::udp::endpoint &sender) {
     TRACE("Waiting for a chunk at ("
-	  << team_socket_.local_endpoint().address().to_string() << ","
-	  << std::to_string(team_socket_.local_endpoint().port()) << ")");
+          << team_socket_.local_endpoint().address().to_string() << ","
+          << std::to_string(team_socket_.local_endpoint().port()) << ")");
 
     size_t bytes_transferred = team_socket_.receive_from(buffer(message), sender);
     message.resize(bytes_transferred);
     recvfrom_counter_++;
 
     TRACE("Received a message from ("
-	  << sender.address().to_string() << "," << std::to_string(sender.port())
-	  << ") of length " << std::to_string(message.size()));
+          << sender.address().to_string() << "," << std::to_string(sender.port())
+          << ") of length " << std::to_string(message.size()));
 
     if (message.size() < 10) {
       TRACE("Message content = " << std::string(message.data()));
@@ -336,7 +336,7 @@ namespace p2psp {
   }
 
   int PeerIMS::ProcessMessage(const std::vector<char> &message,
-			      const ip::udp::endpoint &sender) {
+                              const ip::udp::endpoint &sender) {
     // Ojo, an attacker could send a packet smaller and pollute the buffer,
     // althought this is difficult in IP multicst. This method should be
     // inheritaged to solve this issue.
@@ -369,18 +369,18 @@ namespace p2psp {
     while (received_counter_ < buffer_size_ / 2) {
       chunk_number = ProcessNextMessage();
       while (chunk_number < 0) {
-	chunk_number = ProcessNextMessage();
+        chunk_number = ProcessNextMessage();
       }
     }
 
     if (show_buffer_) {
       for (int i = 0; buffer_size_; i++) {
-	if (chunks_[i].received) {
-	  // TODO: Avoid line feed in LOG function
-	  TRACE(std::to_string(i % 10));
-	} else {
-	  TRACE(".");
-	}
+        if (chunks_[i].received) {
+          // TODO: Avoid line feed in LOG function
+          TRACE(std::to_string(i % 10));
+        } else {
+          TRACE(".");
+        }
       }
       TRACE("");
     }
@@ -484,7 +484,7 @@ namespace p2psp {
   uint16_t PeerIMS::GetPlayerPort() {
     return  player_port_;
   }
-  
+
   //void PeerIMS::SetSplitterAddr(std::string splitter_addr) {
   void PeerIMS::SetSplitterAddr(ip::address splitter_addr) {
     splitter_addr_ = splitter_addr;//ip::address::from_string(splitter_addr);
@@ -497,11 +497,11 @@ namespace p2psp {
   uint16_t PeerIMS::GetSplitterPort() {
     return splitter_port_;
   }
-  
+
   ip::address PeerIMS::GetSplitterAddr() {
     return splitter_addr_;
   }
-  
+
   void PeerIMS::SetTeamPort(uint16_t team_port) {
     team_port_ = team_port;
   }
@@ -509,7 +509,7 @@ namespace p2psp {
   uint16_t PeerIMS::GetTeamPort() {
     return team_port_;
   }
-  
+
   void PeerIMS::SetUseLocalhost(bool use_localhost) {
     use_localhost_ = use_localhost;
   }

--- a/src/core/peer_ims.h
+++ b/src/core/peer_ims.h
@@ -33,7 +33,7 @@ namespace p2psp {
     std::vector<char> data;
     bool received;
   };
-  
+
   class PeerIMS {
 
   protected:
@@ -46,7 +46,7 @@ namespace p2psp {
     static const int kBufferStatus = 0;                   // Default ?
     static const bool kShowBuffer = false;                // Default
     static const int kChunkIndexSize = 2;
-  
+
     uint16_t player_port_;                                // Port used to serve the player.
     ip::address splitter_addr_;                           // Address of the splitter.
     uint16_t splitter_port_;                              // Port of the splitter.
@@ -108,7 +108,7 @@ namespace p2psp {
     virtual void ListenToTheTeam();
     virtual void ReceiveTheNextMessage(std::vector<char>&, ip::udp::endpoint&);
     virtual int ProcessMessage(const std::vector<char>&,
-			       const ip::udp::endpoint&);
+                               const ip::udp::endpoint&);
     virtual int ProcessNextMessage();
 
     /**
@@ -149,7 +149,7 @@ namespace p2psp {
     virtual void     SetTeamPort(uint16_t);
     virtual uint16_t GetTeamPort();
     virtual void SetUseLocalhost(bool);
-    
+
   };
 }
 

--- a/src/core/python.cc
+++ b/src/core/python.cc
@@ -15,7 +15,7 @@
 using namespace p2psp;
 using namespace boost::python;
 
-class acquireGIL 
+class acquireGIL
 {
 public:
     inline acquireGIL(){
@@ -51,7 +51,7 @@ public:
     releaseGIL unlock;
     PeerDBS::Run();
   }
-  
+
   list GetPeerList_() {
     list l;
     std::string address;
@@ -67,11 +67,11 @@ public:
   std::string GetMcastAddr_(){
     return mcast_addr_.to_string();
   }
-  
+
   void SetMcastAddr_(std::string address){
     mcast_addr_ = ip::address::from_string(address);
   }
-  
+
   std::string GetSplitterAddr_(){
     return splitter_addr_.to_string();
   }
@@ -79,7 +79,7 @@ public:
   void SetSplitterAddr_(std::string address){
     splitter_addr_ = ip::address::from_string(address);
   }
-  
+
   void SetChunkSize(int chunk_size){
     chunk_size_ = chunk_size;
   }
@@ -88,7 +88,7 @@ public:
     recvfrom_counter_ = recvfrom_counter;
   }
   */
-  
+
   bool GetShowBuffer(){
     return show_buffer_;
   }
@@ -107,19 +107,19 @@ public:
     releaseGIL unlock;
     PeerDBS::Run();
   }
-  
+
   int ProcessMessage(const std::vector<char> &message, const ip::udp::endpoint &sender) {
     acquireGIL lock;
-    if (override ProcessMessage = get_override("ProcessMessage")){     
+    if (override ProcessMessage = get_override("ProcessMessage")){
       std::string address = sender.address().to_string();
       uint16_t port = sender.port();
-      
+
       boost::python::object memoryView(boost::python::handle<>(PyMemoryView_FromMemory((char*)message.data(), message.size(), PyBUF_READ)));
       return ProcessMessage(memoryView, boost::python::make_tuple(address, port));
     }
     return PeerDBS::ProcessMessage(message, sender);
   }
-  
+
 
   int SendChunk(boost::python::object message, boost::python::tuple peer){
     ip::address address = boost::asio::ip::address::from_string(boost::python::extract<std::string>(peer[0]));
@@ -128,7 +128,7 @@ public:
     boost::python::object locals(boost::python::borrowed(PyEval_GetLocals()));
     boost::python::stl_input_iterator<unsigned char> begin(message), end;
     std::vector<char> msg(begin, end);
-   
+
     return team_socket_.send_to(::buffer(msg), boost::asio::ip::udp::endpoint(address,port));
   }
 
@@ -141,7 +141,7 @@ public:
 
   boost::python::object GetReceiveAndFeedPrevious(){
      boost::python::object receive_and_fedd_previous(boost::python::handle<>(PyMemoryView_FromMemory((char*)receive_and_feed_previous_.data(), receive_and_feed_previous_.size(), PyBUF_READ)));
-    return receive_and_fedd_previous; 
+    return receive_and_fedd_previous;
   }
 
   void SetReceiveAndFeedPrevious(boost::python::object receive_and_fedd_previous){
@@ -202,7 +202,7 @@ public:
   std::string GetMcastAddr_(){
     return mcast_addr_.to_string();
   }
-  
+
   void SetMcastAddr_(std::string address){
     mcast_addr_ = ip::address::from_string(address);
   }
@@ -214,7 +214,7 @@ public:
   void SetRecvfromCounter(int recvfrom_counter){
     recvfrom_counter_ = recvfrom_counter;
   }
-  
+
   std::string GetSplitterAddr_(){
     return splitter_addr_.to_string();
   }
@@ -222,19 +222,19 @@ public:
   void SetSplitterAddr_(std::string address){
     splitter_addr_ = ip::address::from_string(address);
   }
-  
+
   uint16_t GetPlayerPort(){
     return player_port_;
   }
-  
+
   int GetMaxChunkDebt(){
-	  return max_chunk_debt_;
+          return max_chunk_debt_;
   }
-  
+
   bool GetUseLocalhost(){
     return use_localhost_;
   }
-  
+
   bool GetShowBuffer(){
     return show_buffer_;
   }
@@ -271,7 +271,7 @@ public:
     receive_and_feed_counter_ = receive_and_feed_counter;
   }
 };
-  
+
 //Splitter
 class PySplitterDBS: public SplitterDBS {
 public:
@@ -287,7 +287,7 @@ public:
     }
     return l;
   }
-  
+
   int GetLoss_(boost::python::tuple peer){
     ip::address address = boost::asio::ip::address::from_string(boost::python::extract<std::string>(peer[0]));
     uint16_t port = boost::python::extract<uint16_t>(peer[1]);
@@ -297,15 +297,15 @@ public:
   std::string GetChannel(){
     return channel_;
   }
-  
+
   std::string GetSourceAddr(){
     return source_addr_;
   }
-    
+
   int GetBufferSize(){
     return buffer_size_;
   }
-  
+
   int GetHeaderSize(){
     return header_size_;
   }
@@ -319,7 +319,7 @@ public:
     uint16_t port = boost::python::extract<uint16_t>(peer[1]);
     peer_list_.push_back(boost::asio::ip::udp::endpoint(address,port));
   }
-  
+
 
 };
 
@@ -328,9 +328,9 @@ BOOST_PYTHON_MODULE(libp2psp)
   PyEval_InitThreads();
   class_<std::vector<char> >("CharVec")
             .def(vector_indexing_suite<std::vector<char> >());
-  
+
   class_<PyPeerDBS, boost::noncopyable>("PeerDBS")
-    
+
     //variables
     .add_property("splitter_addr", &PyPeerDBS::GetSplitterAddr_, &PyPeerDBS::SetSplitterAddr_)
     .add_property("splitter_port", &PyPeerDBS::GetSplitterPort, &PyPeerDBS::SetSplitterPort)
@@ -348,13 +348,13 @@ BOOST_PYTHON_MODULE(libp2psp)
     .add_property("receive_and_feed_previous" , &PyPeerDBS::GetReceiveAndFeedPrevious, &PyPeerDBS::SetReceiveAndFeedPrevious)
     .add_property("sendto_counter", &PyMonitorDBS::GetSendtoCounter, &PyMonitorDBS::SetSendtoCounter)
 
-    
+
     //IMS
     .def("Init", &PeerDBS::Init) //used
     .def("WaitForThePlayer", &PeerDBS::WaitForThePlayer)
     .def("ConnectToTheSplitter", &PeerDBS::ConnectToTheSplitter)
     .def("DisconnectFromTheSplitter", &PeerDBS::DisconnectFromTheSplitter)
-    .def("ReceiveTheMcastEndpoint", &PeerDBS::ReceiveTheMcastEndpoint) 
+    .def("ReceiveTheMcastEndpoint", &PeerDBS::ReceiveTheMcastEndpoint)
     .def("ReceiveTheHeader", &PeerDBS::ReceiveTheHeader)
     .def("ReceiveTheChunkSize", &PeerDBS::ReceiveTheChunkSize)
     .def("ReceiveTheHeaderSize", &PeerDBS::ReceiveTheHeaderSize)
@@ -372,7 +372,7 @@ BOOST_PYTHON_MODULE(libp2psp)
     .def("IsPlayerAlive", &PeerDBS::IsPlayerAlive)
     .def("GetPlayedChunk", &PeerDBS::GetPlayedChunk)
     .def("GetPeerList", &PyPeerDBS::GetPeerList_) //Modified here
-    
+
     //DBS
     .def("SayHello", &PyPeerDBS::SayHello)
     .def("SayGoodbye", &PyPeerDBS::SayGoodbye)
@@ -396,7 +396,7 @@ BOOST_PYTHON_MODULE(libp2psp)
     .def("GetDebt", &PyPeerDBS::GetDebt)
     .def("RemoveDebt", &PyPeerDBS::RemoveDebt)
     .def("SetDebt", &PyPeerDBS::SetDebt)
-	 
+
     //Overrides
     .def("ProcessMessage", &PyPeerDBS::ProcessMessage)
     .def("SendChunk", &PyPeerDBS::SendChunk)
@@ -421,7 +421,7 @@ BOOST_PYTHON_MODULE(libp2psp)
     .def("WaitForThePlayer", &PyMonitorDBS::WaitForThePlayer)
     .def("ConnectToTheSplitter", &PyMonitorDBS::ConnectToTheSplitter)
     .def("DisconnectFromTheSplitter", &PyMonitorDBS::DisconnectFromTheSplitter)
-    .def("ReceiveTheMcastEndpoint", &PyMonitorDBS::ReceiveTheMcastEndpoint) 
+    .def("ReceiveTheMcastEndpoint", &PyMonitorDBS::ReceiveTheMcastEndpoint)
     .def("ReceiveTheHeader", &PyMonitorDBS::ReceiveTheHeader)
     .def("ReceiveTheChunkSize", &PyMonitorDBS::ReceiveTheChunkSize)
     .def("ReceiveTheHeaderSize", &PyMonitorDBS::ReceiveTheHeaderSize)
@@ -458,9 +458,9 @@ BOOST_PYTHON_MODULE(libp2psp)
     .def("Run", &PyMonitorDBS::Run)
     .def("AmIAMonitor", &PyMonitorDBS::AmIAMonitor)
     .def("GetNumberOfPeers", &PyMonitorDBS::GetNumberOfPeers)
-    .def("SetMaxChunkDebt", &PyMonitorDBS::SetMaxChunkDebt) 
+    .def("SetMaxChunkDebt", &PyMonitorDBS::SetMaxChunkDebt)
     ;
-  
+
   class_<PySplitterDBS, boost::noncopyable>("SplitterDBS")
     //Variables
     .add_property("buffer_size", &PySplitterDBS::GetBufferSize, &PySplitterDBS::SetBufferSize)
@@ -472,8 +472,8 @@ BOOST_PYTHON_MODULE(libp2psp)
     .add_property("source_port", &PySplitterDBS::GetSourcePort, &PySplitterDBS::SetSourcePort)
     .add_property("max_number_of_chunk_loss", &PySplitterDBS::GetMaxNumberOfChunkLoss, &PySplitterDBS::SetMaxNumberOfChunkLoss)
     .add_property("max_number_of_monitors", &PySplitterDBS::GetMaxNumberOfMonitors, &PySplitterDBS::SetMaxNumberOfMonitors)
-    
-    
+
+
     //IMS
     .def("SendTheHeader", &PySplitterDBS::SendTheHeader)
     .def("SendTheBufferSize", &PySplitterDBS::SendTheBufferSize)

--- a/src/core/splitter_dbs.cc
+++ b/src/core/splitter_dbs.cc
@@ -39,7 +39,7 @@ namespace p2psp {
   }
 
   void SplitterDBS::SendMagicFlags(
-				   const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
+                                   const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     char message[1];
 
     message[0] = magic_flags_;
@@ -48,7 +48,7 @@ namespace p2psp {
   }
 
   void SplitterDBS::SendTheListSize(
-				    const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
+                                    const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     char message[2];
 
     TRACE("Sending the number of monitors " << max_number_of_monitors_);
@@ -61,7 +61,7 @@ namespace p2psp {
   }
 
   void SplitterDBS::SendTheListOfPeers(
-				       const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
+                                       const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     SendTheListSize(peer_serve_socket);
 
     int counter = 0;
@@ -70,7 +70,7 @@ namespace p2psp {
     in_addr addr;
 
     for (std::vector<asio::ip::udp::endpoint>::iterator it = peer_list_.begin();
-	 it != peer_list_.end(); ++it) {
+         it != peer_list_.end(); ++it) {
       inet_aton(it->address().to_string().c_str(), &addr);
       (*(in_addr *)&message) = addr;
       (*(uint16_t *)(message + 4)) = htons(it->port());
@@ -82,7 +82,7 @@ namespace p2psp {
   }
 
   void SplitterDBS::SendThePeerEndpoint(
-					const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
+                                        const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     asio::ip::tcp::endpoint peer_endpoint = peer_serve_socket->remote_endpoint();
 
     char message[6];
@@ -94,7 +94,7 @@ namespace p2psp {
   }
 
   void SplitterDBS::SendConfiguration(
-				      const std::shared_ptr<boost::asio::ip::tcp::socket> &sock) {
+                                      const std::shared_ptr<boost::asio::ip::tcp::socket> &sock) {
     SplitterIMS::SendConfiguration(sock);
     SendThePeerEndpoint(sock);
     SendMagicFlags(sock);
@@ -110,7 +110,7 @@ namespace p2psp {
   }
 
   void SplitterDBS::HandleAPeerArrival(
-				       std::shared_ptr<boost::asio::ip::tcp::socket> serve_socket) {
+                                       std::shared_ptr<boost::asio::ip::tcp::socket> serve_socket) {
     /* In the DBS, the splitter sends to the incomming peer the
        list of peers. Notice that the transmission of the list of
        peers (something that could need some time if the team is
@@ -126,13 +126,13 @@ namespace p2psp {
     SendTheListOfPeers(serve_socket);
     serve_socket->close();
     InsertPeer(boost::asio::ip::udp::endpoint(incoming_peer.address(),
-					      incoming_peer.port()));
+                                              incoming_peer.port()));
 
     // TODO: In original code, incoming_peer is returned, but is not used
   }
 
   size_t SplitterDBS::ReceiveMessage(std::vector<char> &message,
-				     boost::asio::ip::udp::endpoint &endpoint) {
+                                     boost::asio::ip::udp::endpoint &endpoint) {
     system::error_code ec;
 
     size_t bytes_transferred =
@@ -146,7 +146,7 @@ namespace p2psp {
   }
 
   void SplitterDBS::IncrementUnsupportivityOfPeer(
-						  const boost::asio::ip::udp::endpoint &peer) {
+                                                  const boost::asio::ip::udp::endpoint &peer) {
     bool peerExists = true;
 
     try {
@@ -167,14 +167,14 @@ namespace p2psp {
   }
 
   void SplitterDBS::ProcessLostChunk(
-				     int lost_chunk_number, const boost::asio::ip::udp::endpoint &sender) {
+                                     int lost_chunk_number, const boost::asio::ip::udp::endpoint &sender) {
     asio::ip::udp::endpoint destination = GetLosser(lost_chunk_number);
 
     TRACE("" << sender << " complains about lost chunk "
-	  << to_string(lost_chunk_number) << " sent to " << destination);
+          << to_string(lost_chunk_number) << " sent to " << destination);
 
     if (find(peer_list_.begin() + max_number_of_monitors_, peer_list_.end(),
-	     destination) != peer_list_.end()) {
+             destination) != peer_list_.end()) {
       TRACE("Lost chunk index = " << lost_chunk_number);
     }
 
@@ -194,15 +194,15 @@ namespace p2psp {
     // If peer_list_ contains the peer, remove it
     if (find(peer_list_.begin(), peer_list_.end(), peer) != peer_list_.end()) {
       peer_list_.erase(remove(peer_list_.begin(), peer_list_.end(), peer),
-		       peer_list_.end());
+                       peer_list_.end());
 
       // In order to avoid negative peer_number_ value while peer_list_ still
       // contains any peer (in Python this is not necessary because negative
       // indexes can be used)
       if (peer_list_.size() > 0) {
-	peer_number_ = (peer_number_ - 1) % peer_list_.size();
+        peer_number_ = (peer_number_ - 1) % peer_list_.size();
       } else {
-	peer_number_--;
+        peer_number_--;
       }
     }
 
@@ -225,27 +225,27 @@ namespace p2psp {
       size_t bytes_transferred = ReceiveMessage(message, sender);
 
       if (bytes_transferred == 2) {
-	/*
-	  The peer complains about a lost chunk.
+        /*
+          The peer complains about a lost chunk.
 
-	  In this situation, the splitter counts the number of
-	  complains. If this number exceeds a threshold, the
-	  unsupportive peer is expelled from the
-	  team.
-	*/
+          In this situation, the splitter counts the number of
+          complains. If this number exceeds a threshold, the
+          unsupportive peer is expelled from the
+          team.
+        */
 
-	uint16_t lost_chunk_number = GetLostChunkNumber(message);
-	ProcessLostChunk(lost_chunk_number, sender);
+        uint16_t lost_chunk_number = GetLostChunkNumber(message);
+        ProcessLostChunk(lost_chunk_number, sender);
 
       } else {
-	/*
-	  The peer wants to leave the team.
+        /*
+          The peer wants to leave the team.
 
-	  A !2-length payload means that the peer wants to go
-	  away.
-	*/
+          A !2-length payload means that the peer wants to go
+          away.
+        */
 
-	ProcessGoodbye(sender);
+        ProcessGoodbye(sender);
       }
     }
   }
@@ -311,22 +311,22 @@ namespace p2psp {
       asio::streambuf chunk;
       size_t bytes_transferred = ReceiveChunk(chunk);
       try {
-	peer = peer_list_.at(peer_number_);
+        peer = peer_list_.at(peer_number_);
 
-	(*(uint16_t *)message.data()) = htons(chunk_number_);
+        (*(uint16_t *)message.data()) = htons(chunk_number_);
 
-	copy(asio::buffer_cast<const char *>(chunk.data()),
-	     asio::buffer_cast<const char *>(chunk.data()) + chunk.size(),
-	     message.data() + sizeof(uint16_t));
+        copy(asio::buffer_cast<const char *>(chunk.data()),
+             asio::buffer_cast<const char *>(chunk.data()) + chunk.size(),
+             message.data() + sizeof(uint16_t));
 
-	SendChunk(message, peer);
+        SendChunk(message, peer);
 
-	destination_of_chunk_[chunk_number_ % buffer_size_] = peer;
-	chunk_number_ = (chunk_number_ + 1) % Common::kMaxChunkNumber;
-	ComputeNextPeerNumber(peer);
+        destination_of_chunk_[chunk_number_ % buffer_size_] = peer;
+        chunk_number_ = (chunk_number_ + 1) % Common::kMaxChunkNumber;
+        ComputeNextPeerNumber(peer);
       } catch (const std::out_of_range &oor) {
-	TRACE("The monitor peer has died!");
-	exit(-1);
+        TRACE("The monitor peer has died!");
+        exit(-1);
       }
 
       chunk.consume(bytes_transferred);
@@ -348,7 +348,7 @@ namespace p2psp {
   int SplitterDBS::GetMaxNumberOfChunkLoss() {
     return max_number_of_chunk_loss_;
   }
-  
+
   void SplitterDBS::SetMaxNumberOfMonitors(int max_number_of_monitors) {
     max_number_of_monitors_ = max_number_of_monitors;
   }
@@ -356,7 +356,7 @@ namespace p2psp {
   int SplitterDBS::GetMaxNumberOfMonitors() {
     return max_number_of_monitors_;
   }
-  
+
   void SplitterDBS::Start() {
     TRACE("Start");
     thread_.reset(new boost::thread(boost::bind(&SplitterDBS::Run, this)));

--- a/src/core/splitter_ims.cc
+++ b/src/core/splitter_ims.cc
@@ -65,7 +65,7 @@ namespace p2psp {
     } catch (system::system_error &error) {
       ERROR(error.what());
       ERROR(acceptor_.local_endpoint().address().to_string() +
-	    "\b: unable to bind the port " + to_string(team_port_));
+            "\b: unable to bind the port " + to_string(team_port_));
       exit(-1);
     }
 
@@ -100,50 +100,50 @@ namespace p2psp {
   void SplitterIMS::RequestTheVideoFromTheSource() {
     system::error_code ec;
     asio::ip::tcp::endpoint endpoint(asio::ip::address::from_string(source_addr_),
-				     source_port_);
+                                     source_port_);
 
     source_socket_.connect(endpoint, ec);
 
     if (ec) {
       ERROR(ec.message());
       ERROR(source_socket_.local_endpoint().address().to_string()
-	    << "\b: unable to connect to the source (" << source_addr_ << ", "
-	    << to_string(source_port_) << ")");
+            << "\b: unable to connect to the source (" << source_addr_ << ", "
+            << to_string(source_port_) << ")");
 
       source_socket_.close();
       exit(-1);
     }
 
     TRACE(source_socket_.local_endpoint().address().to_string()
-	  << " connected to (" << source_addr_ << ", " << to_string(source_port_)
-	  << ")");
+          << " connected to (" << source_addr_ << ", " << to_string(source_port_)
+          << ")");
 
     source_socket_.send(asio::buffer(GET_message_));
 
     TRACE(source_socket_.local_endpoint().address().to_string()
-	  << "IMS: GET_message = " << GET_message_);
+          << "IMS: GET_message = " << GET_message_);
   }
 
   size_t SplitterIMS::ReceiveNextChunk(asio::streambuf &chunk) {
     system::error_code ec;
 
     size_t bytes_transferred = asio::read(
-					  source_socket_, chunk, asio::transfer_exactly(chunk_size_), ec);
+                                          source_socket_, chunk, asio::transfer_exactly(chunk_size_), ec);
 
     // TRACE("Success! Bytes transferred: " << bytes_transferred);
 
     if (ec) {
       ERROR("Error receiving next chunk: "
-	    << ec.message() << " bytes transferred: " << bytes_transferred);
+            << ec.message() << " bytes transferred: " << bytes_transferred);
       TRACE("No data in the server!");
       source_socket_.close();
       header_load_counter_ = header_size_;
       header_.consume(header_.size());
       this_thread::sleep(posix_time::seconds(1));
       source_socket_.connect(
-			     asio::ip::tcp::endpoint(asio::ip::address::from_string(source_addr_),
-						     source_port_),
-			     ec);
+                             asio::ip::tcp::endpoint(asio::ip::address::from_string(source_addr_),
+                                                     source_port_),
+                             ec);
       source_socket_.send(asio::buffer(GET_message_));
     }
 
@@ -156,7 +156,7 @@ namespace p2psp {
     if (header_load_counter_ > 0) {
       ostream header_stream_(&header_);
       header_stream_.write(asio::buffer_cast<const char *>(chunk.data()),
-			   chunk.size());
+                           chunk.size());
       header_load_counter_--;
       TRACE("Loaded" << to_string(chunk.size()) << " bytes of header");
     }
@@ -183,7 +183,7 @@ namespace p2psp {
   }
 
   void SplitterIMS::SendChunk(const vector<char> &message,
-			      const asio::ip::udp::endpoint &destination) {
+                              const asio::ip::udp::endpoint &destination) {
     system::error_code ec;
 
     // TRACE(std::to_string(ntohs(*(unsigned short *)message.data())));
@@ -203,9 +203,9 @@ namespace p2psp {
   }
 
   void SplitterIMS::SendTheMcastChannel(
-					const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
+                                        const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     TRACE("Communicating the multicast channel (" << mcast_addr_ << ", "
-	  << to_string(team_port_) << ")");
+          << to_string(team_port_) << ")");
 
     char message[6];
     in_addr addr;
@@ -216,7 +216,7 @@ namespace p2psp {
   }
 
   void SplitterIMS::SendTheHeaderSize(
-				      const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
+                                      const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     TRACE("Communicating the header size " << to_string(header_size_));
 
     system::error_code ec;
@@ -230,7 +230,7 @@ namespace p2psp {
   }
 
   void SplitterIMS::SendTheChunkSize(
-				     const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
+                                     const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     TRACE("Sending a chunk_size of " << to_string(chunk_size_) << " bytes");
 
     system::error_code ec;
@@ -244,7 +244,7 @@ namespace p2psp {
   }
 
   void SplitterIMS::SendTheHeader(
-				  const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
+                                  const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     TRACE("Sending a header of " << to_string(header_.size()) << " bytes");
 
     system::error_code ec;
@@ -256,7 +256,7 @@ namespace p2psp {
   }
 
   void SplitterIMS::SendTheBufferSize(
-				      const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
+                                      const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     TRACE("Sending a buffer_size of " << to_string(buffer_size_) << " bytes");
 
     system::error_code ec;
@@ -270,7 +270,7 @@ namespace p2psp {
   }
 
   void SplitterIMS::SendConfiguration(
-				      const std::shared_ptr<boost::asio::ip::tcp::socket> &sock) {
+                                      const std::shared_ptr<boost::asio::ip::tcp::socket> &sock) {
     SendTheMcastChannel(sock);
     SendTheHeaderSize(sock);
     SendTheChunkSize(sock);
@@ -279,11 +279,11 @@ namespace p2psp {
   }
 
   void SplitterIMS::HandleAPeerArrival(
-				       std::shared_ptr<asio::ip::tcp::socket> serve_socket) {
+                                       std::shared_ptr<asio::ip::tcp::socket> serve_socket) {
     TRACE(serve_socket->local_endpoint().address().to_string()
-	  << "\b: IMS: accepted connection from peer ("
-	  << serve_socket->remote_endpoint().address().to_string() << ", "
-	  << to_string(serve_socket->remote_endpoint().port()) << ")");
+          << "\b: IMS: accepted connection from peer ("
+          << serve_socket->remote_endpoint().address().to_string() << ", "
+          << to_string(serve_socket->remote_endpoint().port()) << ")");
 
     SendConfiguration(serve_socket);
     serve_socket->close();
@@ -298,7 +298,7 @@ namespace p2psp {
         make_shared<asio::ip::tcp::socket>(boost::ref(io_service_));
       acceptor_.accept(*peer_serve_socket);
       threads.create_thread(
-			    bind(&SplitterIMS::HandleAPeerArrival, this, peer_serve_socket));
+                            bind(&SplitterIMS::HandleAPeerArrival, this, peer_serve_socket));
     }
 
     TRACE("Exiting handle arrivals");
@@ -329,8 +329,8 @@ namespace p2psp {
       (*(uint16_t *)message.data()) = htons(chunk_number_);
 
       copy(asio::buffer_cast<const char *>(chunk.data()),
-	   asio::buffer_cast<const char *>(chunk.data()) + chunk.size(),
-	   message.data() + sizeof(uint16_t));
+           asio::buffer_cast<const char *>(chunk.data()) + chunk.size(),
+           message.data() + sizeof(uint16_t));
 
       SendChunk(message, mcast_channel_);
 
@@ -345,7 +345,7 @@ namespace p2psp {
     message[0] = '\0';
 
     asio::ip::udp::endpoint destination(
-					asio::ip::address::from_string("127.0.0.1"), team_port_);
+                                        asio::ip::address::from_string("127.0.0.1"), team_port_);
 
     system::error_code ec;
 
@@ -374,7 +374,7 @@ namespace p2psp {
   void SplitterIMS::SetBufferSize(int buffer_size) { buffer_size_ = buffer_size; }
 
   int SplitterIMS::GetBufferSize() { return buffer_size_; }
-  
+
   void SplitterIMS::SetChannel(std::string channel) {
     channel_ = channel;
     SetGETMessage(channel_);
@@ -403,7 +403,7 @@ namespace p2psp {
   int SplitterIMS::GetTTL() {
     return ttl_;
   }
-  
+
   void SplitterIMS::SetGETMessage(std::string channel) {
     std::stringstream ss;
     ss << "GET /" << channel << " HTTP/1.1\r\n"

--- a/src/core/splitter_ims.h
+++ b/src/core/splitter_ims.h
@@ -72,7 +72,7 @@ namespace p2psp {
     std::string GetSourceAddr();
     int GetSourcePort();
     int GetTTL();
-  
+
     // Setters
     void SetAlive(bool alive);
     void SetBufferSize(int buffer_size);

--- a/src/core/trusted_peer.h
+++ b/src/core/trusted_peer.h
@@ -40,7 +40,7 @@ class TrustedPeer : public MaliciousPeer {
   virtual int CalculateNextSampled();
   virtual void SendChunkHash(int);
   virtual void ReceiveTheNextMessage(std::vector<char> &,
-                                     ip::udp::endpoint &) override; 
+                                     ip::udp::endpoint &) override;
   virtual float CalcBufferCorrectness() override;
   virtual int ProcessNextMessage() override;
 };


### PR DESCRIPTION
This doesn't change anything substantial, just cleans up the code a bit.

Used scripts snippets:
`sed -i 's/\t/        /g' src/core/*{cc,h}` and `sed -i 's/  *$//g' src/core/*{cc,h}`.

Sorry for the duplication, I accidentally pushed this to master.