### PR TITLE
Fix NTS, increase header size, fix 'protected' attributes for NTS methods.

### DIFF
--- a/src/core/monitor_nts.h
+++ b/src/core/monitor_nts.h
@@ -20,8 +20,12 @@ namespace p2psp {
 
   class Monitor_NTS : public Peer_NTS {
   public:
+    Monitor_NTS();
+    ~Monitor_NTS();
+    virtual void Init() override;
+
     // These two are from Monitor_DBS:
-    virtual void Complain(uint16_t);
+    virtual void Complain(uint16_t) override;
     //virtual int FindNextChunk() override;
 
     // Receive the generated ID for this peer from splitter and disconnect
@@ -30,11 +34,6 @@ namespace p2psp {
     // Handle NTS messages; pass other messages to base class
     virtual int ProcessMessage(const std::vector<char>& message_bytes,
 			       const ip::udp::endpoint& sender) override;
-
-  public:
-    Monitor_NTS();
-    ~Monitor_NTS();
-    virtual void Init() override;
   };
 }
 

--- a/src/core/peer_nts.h
+++ b/src/core/peer_nts.h
@@ -33,7 +33,7 @@ namespace p2psp {
   };
 
   class Peer_NTS : public Peer_DBS {
-  public:
+  protected:
     std::string peer_id_;
     std::mutex hello_messages_lock_;
     std::list<HelloMessage> hello_messages_;
@@ -45,7 +45,6 @@ namespace p2psp {
 
     std::thread send_hello_thread_;
 
-    virtual void SayHello(const ip::udp::endpoint& peer) override;
     virtual void SendHello(const ip::udp::endpoint& peer,
 			   std::vector<uint16_t> additional_ports = {});
 
@@ -59,7 +58,6 @@ namespace p2psp {
 			     boost::asio::ip::udp::endpoint endpoint);
     virtual void StartSendHelloThread();
     virtual void ReceiveTheListOfPeers2();
-    virtual void DisconnectFromTheSplitter() override;
     virtual void TryToDisconnectFromTheSplitter();
 
     virtual std::set<uint16_t> GetFactors(uint16_t n);
@@ -77,14 +75,16 @@ namespace p2psp {
 							 uint16_t source_port_to_splitter, uint16_t port_diff,
 							 uint16_t peer_number);
 
-    // Handle NTS messages; pass other messages to base class
-    virtual int ProcessMessage(const std::vector<char>& message,
-			       const ip::udp::endpoint& sender) override;
-
   public:
     Peer_NTS();
     ~Peer_NTS();
     virtual void Init() override;
+
+    virtual void SayHello(const ip::udp::endpoint& peer) override;
+    virtual void DisconnectFromTheSplitter() override;
+    // Handle NTS messages; pass other messages to base class
+    virtual int ProcessMessage(const std::vector<char>& message,
+			       const ip::udp::endpoint& sender) override;
   };
 }
 

--- a/src/core/splitter_core.cc
+++ b/src/core/splitter_core.cc
@@ -22,8 +22,8 @@ namespace p2psp {
   const unsigned short Splitter_core::kSplitterPort = 8001;   // Listening port
   const std::string Splitter_core::kSourceAddr = "127.0.0.1"; // Streaming server's host
   const int Splitter_core::kSourcePort = 8000;                // Streaming server's listening port
-  const int Splitter_core::kHeaderSize = 4000;
-  
+  const int Splitter_core::kHeaderSize = 8192;
+
   Splitter_core::Splitter_core()
     : io_service_(),
       peer_connection_socket_(io_service_),
@@ -37,7 +37,7 @@ namespace p2psp {
     source_addr_ = kSourceAddr;
     source_port_ = kSourcePort;
     header_size_ = kHeaderSize;
-    
+
     alive_ = true;
     chunk_number_ = 0;
 
@@ -58,7 +58,7 @@ namespace p2psp {
   int Splitter_core::GetDefaultHeaderSize() {
     return kHeaderSize;
   }
-  
+
   void Splitter_core::SetupPeerConnectionSocket() {
     asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), splitter_port_);
     acceptor_.open(endpoint.protocol());
@@ -74,7 +74,7 @@ namespace p2psp {
 
     TRACE("channel size = "
 	  << channel_.length());
-    
+
     (*(uint16_t *)&message) = htons(channel_.length());
     //peer_serve_socket->send(asio::buffer(message), 0, ec);
 
@@ -90,7 +90,7 @@ namespace p2psp {
 
     //boost::system::error_code ignored_error;
     boost::asio::write(*peer_serve_socket, boost::asio::buffer(channel_,channel_.length())/*,boost::asio::transfer_all(), ignored_error*/);
-    
+
     //char message[80];
 
     //peer_serve_socket->send(asio::buffer(channel_));
@@ -219,7 +219,7 @@ namespace p2psp {
     return bytes_transferred;
   }
 
-  
+
   void Splitter_core::SendChunk(const vector<char> &message, const asio::ip::udp::endpoint &destination) {
     system::error_code ec;
 
@@ -233,7 +233,7 @@ namespace p2psp {
 	  << " -> "
 	  << destination);
 #endif
-    
+
     // TRACE("Bytes transferred: " << to_string(bytes_transferred));
 
     if (ec) {
@@ -281,7 +281,7 @@ namespace p2psp {
   HEADER_SIZE_TYPE Splitter_core::GetHeaderSize(void) {
     return this->header_size_;
   }
-  
+
   void Splitter_core::SendHeaderSize(const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
     TRACE("Sending a header size of "
 	  << to_string(header_size_)
@@ -306,7 +306,7 @@ namespace p2psp {
   }
 
   void Splitter_core::HandleAPeerArrival(std::shared_ptr<boost::asio::ip::tcp::socket>) {}
-  
+
   void Splitter_core::HandleArrivals() {
     std::shared_ptr<asio::ip::tcp::socket> peer_serve_socket;
     thread_group threads;
@@ -393,7 +393,7 @@ namespace p2psp {
     }*/
 
   void Splitter_core::Run() {}
-  
+
   int Splitter_core::GetDefaultChunkSize() {
     return kChunkSize;
   }

--- a/src/core/splitter_nts.cc
+++ b/src/core/splitter_nts.cc
@@ -329,7 +329,6 @@ namespace p2psp {
     ip::udp::endpoint new_peer(new_peer_tcp.address(), new_peer_tcp.port());
     LOG("Accepted connection from peer " << new_peer);
     this->SendConfiguration(serve_socket);
-    this->SendTheListOfPeers(serve_socket);
     // Send the generated ID to peer
     std::string peer_id = this->GenerateId();
     LOG("Sending ID " << peer_id << " to peer " << new_peer);

--- a/src/core/splitter_nts.h
+++ b/src/core/splitter_nts.h
@@ -108,8 +108,6 @@ namespace p2psp {
 
     virtual void EnqueueMessage(unsigned int count, const message_t& message);
 
-    virtual size_t ReceiveChunk(boost::asio::streambuf &chunk) override;
-
     // Before sending a message, wait for a chunk from source to avoid network
     // congestion
     virtual void SendMessageThread();
@@ -137,10 +135,6 @@ namespace p2psp {
     // allocated source port of incorporated peers behind SYMSP NATs
     virtual void ListenExtraSocketThread();
 
-    // This method implements the NAT traversal algorithms.
-    virtual void HandleAPeerArrival(
-				    std::shared_ptr<boost::asio::ip::tcp::socket> serve_socket) override;
-
     virtual void IncorporatePeer(const std::string& peer_id);
     virtual void SendNewPeer(const std::string& peer_id,
 			     const boost::asio::ip::udp::endpoint& new_peer,
@@ -151,12 +145,18 @@ namespace p2psp {
 				uint16_t source_port);
     virtual void UpdatePortStep(const boost::asio::ip::udp::endpoint peer,
 				uint16_t& port_step, uint16_t source_port);
-    virtual void RemovePeer(const boost::asio::ip::udp::endpoint& peer) override;
-    virtual void ModerateTheTeam() override;
 
   public:
     Splitter_NTS();
     ~Splitter_NTS();
+
+    virtual size_t ReceiveChunk(boost::asio::streambuf &chunk) override;
+
+    // This method implements the NAT traversal algorithms.
+    virtual void HandleAPeerArrival(
+				    std::shared_ptr<boost::asio::ip::tcp::socket> serve_socket) override;
+    virtual void RemovePeer(const boost::asio::ip::udp::endpoint& peer) override;
+    virtual void ModerateTheTeam() override;
   };
 }
 


### PR DESCRIPTION
This fixes NTS functionality (`SendTheListOfPeers()` was called twice due to recent changes). Also, the header size was increased to 8192, to make an Ogg video playable again.
The `protected` attributes of NTS methods were fixed, to make methods protected and callable, respectively.