### PR TITLE
Development

### DIFF
--- a/doc/CIS/README.md
+++ b/doc/CIS/README.md
@@ -69,3 +69,18 @@ To run bad-mouth attack you can use:
 $ ./peer.py --strpeds --malicious --bad_mouth "127.0.0.1:1234" "127.0.0.1:4321"
 ```
 Malicious peer will complain on given peers.
+
+## P2PSP TMS (Trust Management System)
+
+Current implementation of P2PSP protocol has its own Trust Management System. In order to enable it, you should run STrPe-DS splitter with `--tms` option.
+
+With TMS enabled, splitter remembers all unique complains about poisoned chunks from all the team, and remembers each peer's lifetime value. Using information above splitter makes decision about expelling malicious peer.
+
+Peer's lifetime value is a number of rounds in the team. It updates every round.
+Every round TMS runs. It sums all the unique complains for each peer (multiplied by complainer's trust value), and if this sum will be greater than some threshold value, peer is considered as malicious and will be expelled from the team.
+
+Current implementation of P2PSP has next parameters:
+- `isTmsEnable` - flag for enabling TMS
+- `maxTrust` - maximum trust value for each peer. Trust value can't be greater than this value.
+- `incr` - increment value for trust value. It affects on speed when the peer achieving maximum trust value.
+- `decr` - decrement value for trust value. This value is deducted from TV each time when peer complains about other peer.

--- a/src/core/splitter_strpeds.cc
+++ b/src/core/splitter_strpeds.cc
@@ -347,6 +347,7 @@ void SplitterSTRPEDS::ProcessBadPeersMessage(
 void SplitterSTRPEDS::HandleBadPeerFromTrusted(
 		const boost::asio::ip::udp::endpoint &bad_peer,
 		const boost::asio::ip::udp::endpoint &sender) {
+	peer_unique_complains_[sender].insert(bad_peer);
   if (std::find(peer_list_.begin(), peer_list_.end(), bad_peer) == peer_list_.end()) {
 		AddComplain(bad_peer, sender);
 		if (std::find(bad_peers_.begin(), bad_peers_.end(), bad_peer) == bad_peers_.end()) {
@@ -362,6 +363,7 @@ void SplitterSTRPEDS::HandleBadPeerFromTrusted(
 void SplitterSTRPEDS::HandleBadPeerFromRegular(
 		const boost::asio::ip::udp::endpoint &bad_peer,
 		const boost::asio::ip::udp::endpoint &sender) {
+	peer_unique_complains_[sender].insert(bad_peer);
 	if (std::find(peer_list_.begin(), peer_list_.end(), bad_peer) == peer_list_.end()) {
 		AddComplain(bad_peer, sender);
 	}
@@ -383,8 +385,6 @@ void SplitterSTRPEDS::AddComplain(
 						complains_.size() - 1));
 
 	}
-
-	peer_unique_complains_[sender].insert(bad_peer);
 }
 
 void SplitterSTRPEDS::PunishPeer(const boost::asio::ip::udp::endpoint &peer,

--- a/src/core/splitter_strpeds.cc
+++ b/src/core/splitter_strpeds.cc
@@ -71,10 +71,15 @@ void SplitterSTRPEDS::SendDsaKey(
 }
 
 void SplitterSTRPEDS::GatherBadPeers() {
-  for (unsigned int i=0; i<trusted_peers_.size(); i++) {
-     boost::asio::ip::udp::endpoint tp = trusted_peers_[i];
-     RequestBadPeers(tp);
-  }
+	if (isTmsEnable) {
+		boost::asio::ip::udp::endpoint p = GetPeerForGathering();
+		RequestBadPeers(p);
+	} else {
+		for (unsigned int i=0; i<trusted_peers_.size(); i++) {
+			 boost::asio::ip::udp::endpoint tp = trusted_peers_[i];
+			 RequestBadPeers(tp);
+		}
+	}
 }
 
 asio::ip::udp::endpoint SplitterSTRPEDS::GetPeerForGathering() {
@@ -346,8 +351,10 @@ void SplitterSTRPEDS::HandleBadPeerFromTrusted(
 		AddComplain(bad_peer, sender);
 		if (std::find(bad_peers_.begin(), bad_peers_.end(), bad_peer) == bad_peers_.end()) {
 			bad_peers_.push_back(bad_peer);
-			trusted_peers_discovered_.push_back(sender);
-			LOG("TP discovered" << sender);
+			if (sender.port() != peer_list_[0].port()) {
+				trusted_peers_discovered_.push_back(sender);
+				LOG("TP discovered" << sender);
+			}
 		}
   }
 }


### PR DESCRIPTION
Fix TMS.
- If TMS is enabled then Splitter requests one peer from the team each round (instead of only TPs)
- Splitter can't exclude Monitor Peer (peer_list_[0] in current version)