### PR TITLE
Dynamic creation of monitors in a P2PSP team

### DIFF
--- a/src/core/monitor_dbs.cc
+++ b/src/core/monitor_dbs.cc
@@ -17,6 +17,76 @@ namespace p2psp {
 
   Monitor_DBS::~Monitor_DBS(){};
 
+  void Monitor_DBS::ConnectToTheSplitter() throw(boost::system::system_error) {
+    // {{{
+
+    std::string my_ip;
+
+    // TCP endpoint object to connect to splitter
+    ip::tcp::endpoint splitter_tcp_endpoint(splitter_addr_, splitter_port_);
+
+    // UDP endpoint object to connect to splitter
+    splitter_ = ip::udp::endpoint(splitter_addr_, splitter_port_);
+
+    ip::tcp::endpoint tcp_endpoint;
+
+#if defined __D_PARAMS__
+    TRACE("use_localhost = " << std::string((use_localhost_ ? "True" : "False")));
+#endif
+
+    if (use_localhost_) {
+      my_ip = "0.0.0.0";
+    } else {
+      ip::udp::socket s(io_service_);
+      try {
+        s.connect(splitter_);
+      } catch (boost::system::system_error e) {
+        ERROR(e.what());
+      }
+
+      my_ip = s.local_endpoint().address().to_string();
+      s.close();
+    }
+
+    splitter_socket_.open(splitter_tcp_endpoint.protocol());
+
+#if defined __D_TRAFFIC__
+    TRACE("Connecting to the splitter at ("
+          << splitter_tcp_endpoint.address().to_string()
+    << ","
+          << std::to_string(splitter_tcp_endpoint.port())
+    << ") from "
+    << my_ip);
+#endif
+    
+    if (team_port_ != 0) {
+#if defined __D_TRAFFIC__
+      TRACE("I'm using port"
+      << std::to_string(team_port_));
+#endif
+      tcp_endpoint = ip::tcp::endpoint(ip::address::from_string(my_ip), team_port_);
+      splitter_socket_.set_option(ip::udp::socket::reuse_address(true));      
+    } else {    
+      tcp_endpoint = ip::tcp::endpoint(ip::address::from_string(my_ip), 0);
+    }
+
+    splitter_socket_.bind(tcp_endpoint);
+
+    // Could throw an exception
+    splitter_socket_.connect(splitter_tcp_endpoint);
+
+#if defined __D_TRAFFIC__
+    TRACE("Connected to the splitter at ("
+          << splitter_tcp_endpoint.address().to_string() << ","
+          << std::to_string(splitter_tcp_endpoint.port()) << ")");
+#endif
+    std::string monitor = "M";
+    ip::udp::socket sock(io_service_);
+    sock.send_to(boost::asio::buffer(monitor,monitor.length()),splitter_);
+    sock.close();
+    // }}}
+  }
+
   void Monitor_DBS::Init() {
 #if defined __D__ || defined __D_SORS__
     TRACE("Initialized");

--- a/src/core/monitor_dbs.cc
+++ b/src/core/monitor_dbs.cc
@@ -81,9 +81,7 @@ namespace p2psp {
           << std::to_string(splitter_tcp_endpoint.port()) << ")");
 #endif
     std::string monitor = "M";
-    ip::udp::socket sock(io_service_);
-    sock.send_to(boost::asio::buffer(monitor,monitor.length()),splitter_);
-    sock.close();
+    splitter_socket_.send(boost::asio::buffer(monitor));
     // }}}
   }
 

--- a/src/core/monitor_dbs.h
+++ b/src/core/monitor_dbs.h
@@ -21,6 +21,7 @@ namespace p2psp {
     ~Monitor_DBS();
     virtual void Init() override;
     virtual void Complain(unsigned short chunk_position /* in buffer */) override;
+    virtual void ConnectToTheSplitter() throw(boost::system::system_error) override;
     //virtual int FindNextChunk() override;
     //virtual void PlayNextChunk(int chunk_number) override;
   };

--- a/src/core/monitor_ems.cc
+++ b/src/core/monitor_ems.cc
@@ -52,7 +52,7 @@ void Monitor_EMS::ConnectToTheSplitter() throw(boost::system::system_error){
     inet_aton(splitter_socket_.local_endpoint().address().to_string().c_str(), &addr);
     (*(in_addr *)&message) = addr;
     (*(uint16_t *)(message + 4)) = htons(splitter_socket_.local_endpoint().port());
-    (*(char *)(message+6))=htons('M');
+    (*(message+6))='M';
     splitter_socket_.send(boost::asio::buffer(message));
 
     INFO("send to splitter local endpoint = (" << splitter_socket_.local_endpoint().address().to_string() << ","

--- a/src/core/monitor_ems.cc
+++ b/src/core/monitor_ems.cc
@@ -42,6 +42,31 @@ DEBUG("lost chunk:" << std::to_string(chunk_number));
 //return chunk_number;
 //}
 
+void Monitor_EMS::ConnectToTheSplitter() throw(boost::system::system_error){
+    // {{{
+
+    Peer_core::ConnectToTheSplitter();
+
+    char message[7];
+    in_addr addr;
+    inet_aton(splitter_socket_.local_endpoint().address().to_string().c_str(), &addr);
+    (*(in_addr *)&message) = addr;
+    (*(uint16_t *)(message + 4)) = htons(splitter_socket_.local_endpoint().port());
+    (*(char *)(message+6))=htons('M');
+    splitter_socket_.send(boost::asio::buffer(message));
+
+    INFO("send to splitter local endpoint = (" << splitter_socket_.local_endpoint().address().to_string() << ","
+          << std::to_string(splitter_socket_.local_endpoint().port()) << ")");
+    std::string monitor = "M";
+    //ip::udp::socket sock(io_service_);
+    //sock.connect(splitter_);
+    TRACE("Sending monitor signal to splitter");
+    //splitter_socket_.send(boost::asio::buffer(monitor));
+    TRACE("Sent");
+    //sock.close();
+    // }}}
+  }
+
 //this is from monitorNTS
 void Monitor_EMS::DisconnectFromTheSplitter() {
     this->StartSendHelloThread();

--- a/src/core/monitor_ems.h
+++ b/src/core/monitor_ems.h
@@ -28,7 +28,7 @@ class Monitor_EMS : public Peer_EMS {
   // These two are from MonitorDBS:
   virtual void Complain(uint16_t);
   //virtual int FindNextChunk() override;
-
+  virtual void ConnectToTheSplitter() throw(boost::system::system_error) override;
   // Receive the generated ID for this peer from splitter and disconnect
   virtual void DisconnectFromTheSplitter() override;
 

--- a/src/core/monitor_nts.cc
+++ b/src/core/monitor_nts.cc
@@ -107,7 +107,7 @@ namespace p2psp {
           << splitter_tcp_endpoint.address().to_string() << ","
           << std::to_string(splitter_tcp_endpoint.port()) << ")");
 #endif
-    std::string monitor = "M";
+    char monitor[1] = {'M'};
     splitter_socket_.send(boost::asio::buffer(monitor));
     // }}}
   }

--- a/src/core/monitor_nts.cc
+++ b/src/core/monitor_nts.cc
@@ -44,6 +44,74 @@ namespace p2psp {
     return chunk_number;
     }*/
 
+  void Monitor_NTS::ConnectToTheSplitter() throw(boost::system::system_error) {
+    // {{{
+
+    std::string my_ip;
+
+    // TCP endpoint object to connect to splitter
+    ip::tcp::endpoint splitter_tcp_endpoint(splitter_addr_, splitter_port_);
+
+    // UDP endpoint object to connect to splitter
+    splitter_ = ip::udp::endpoint(splitter_addr_, splitter_port_);
+
+    ip::tcp::endpoint tcp_endpoint;
+
+#if defined __D_PARAMS__
+    TRACE("use_localhost = " << std::string((use_localhost_ ? "True" : "False")));
+#endif
+
+    if (use_localhost_) {
+      my_ip = "0.0.0.0";
+    } else {
+      ip::udp::socket s(io_service_);
+      try {
+        s.connect(splitter_);
+      } catch (boost::system::system_error e) {
+        ERROR(e.what());
+      }
+
+      my_ip = s.local_endpoint().address().to_string();
+      s.close();
+    }
+
+    splitter_socket_.open(splitter_tcp_endpoint.protocol());
+
+#if defined __D_TRAFFIC__
+    TRACE("Connecting to the splitter at ("
+          << splitter_tcp_endpoint.address().to_string()
+    << ","
+          << std::to_string(splitter_tcp_endpoint.port())
+    << ") from "
+    << my_ip);
+#endif
+    
+    if (team_port_ != 0) {
+#if defined __D_TRAFFIC__
+      TRACE("I'm using port"
+      << std::to_string(team_port_));
+#endif
+      tcp_endpoint = ip::tcp::endpoint(ip::address::from_string(my_ip), team_port_);
+      splitter_socket_.set_option(ip::udp::socket::reuse_address(true));      
+    } else {    
+      tcp_endpoint = ip::tcp::endpoint(ip::address::from_string(my_ip), 0);
+    }
+
+    splitter_socket_.bind(tcp_endpoint);
+
+    // Could throw an exception
+    splitter_socket_.connect(splitter_tcp_endpoint);
+
+#if defined __D_TRAFFIC__
+    TRACE("Connected to the splitter at ("
+          << splitter_tcp_endpoint.address().to_string() << ","
+          << std::to_string(splitter_tcp_endpoint.port()) << ")");
+#endif
+    std::string monitor = "M";
+    splitter_socket_.send(boost::asio::buffer(monitor));
+    // }}}
+  }
+
   void Monitor_NTS::DisconnectFromTheSplitter() {
     this->StartSendHelloThread();
 

--- a/src/core/monitor_nts.h
+++ b/src/core/monitor_nts.h
@@ -27,7 +27,7 @@ namespace p2psp {
     // These two are from Monitor_DBS:
     virtual void Complain(uint16_t) override;
     //virtual int FindNextChunk() override;
-
+    virtual void ConnectToTheSplitter() throw(boost::system::system_error) override;
     // Receive the generated ID for this peer from splitter and disconnect
     virtual void DisconnectFromTheSplitter() override;
 

--- a/src/core/peer_dbs.cc
+++ b/src/core/peer_dbs.cc
@@ -243,6 +243,12 @@ namespace p2psp {
 
   }
 
+  void Peer_DBS::ConnectToTheSplitter() throw(boost::system::system_error){
+  	Peer_core::ConnectToTheSplitter();
+    char monitor[1] = {'P'};
+    splitter_socket_.send(boost::asio::buffer(monitor));
+  }
+
   int Peer_DBS::ProcessMessage(const std::vector<char> &message,
 			       const ip::udp::endpoint &sender) {
     // {{{

--- a/src/core/peer_dbs.h
+++ b/src/core/peer_dbs.h
@@ -56,6 +56,7 @@ namespace p2psp {
     virtual void BufferData() override;
     virtual void Start() override;
     virtual void Run() override;
+    virtual void ConnectToTheSplitter() throw(boost::system::system_error) override;
     bool AmIAMonitor();
 
     int GetNumberOfPeers();

--- a/src/core/peer_ems.cc
+++ b/src/core/peer_ems.cc
@@ -25,11 +25,12 @@ namespace p2psp {
 
     Peer_core::ConnectToTheSplitter();
 
-    char message[6];
+    char message[7];
     in_addr addr;
     inet_aton(splitter_socket_.local_endpoint().address().to_string().c_str(), &addr);
     (*(in_addr *)&message) = addr;
     (*(uint16_t *)(message + 4)) = htons(splitter_socket_.local_endpoint().port());
+    (*(message+6))='P';
     splitter_socket_.send(boost::asio::buffer(message));
 
     INFO("send to splitter local endpoint = (" << splitter_socket_.local_endpoint().address().to_string() << ","

--- a/src/core/peer_nts.cc
+++ b/src/core/peer_nts.cc
@@ -248,6 +248,12 @@ namespace p2psp {
     // }}}
   }
 
+  void Peer_NTS::ConnectToTheSplitter() throw(boost::system::system_error){
+    Peer_core::ConnectToTheSplitter();
+    char monitor[1] = {'P'};
+    splitter_socket_.send(boost::asio::buffer(monitor));
+  }
+
   void Peer_NTS::DisconnectFromTheSplitter() {
     // {{{
 

--- a/src/core/peer_nts.h
+++ b/src/core/peer_nts.h
@@ -59,7 +59,6 @@ namespace p2psp {
     virtual void StartSendHelloThread();
     virtual void ReceiveTheListOfPeers2();
     virtual void TryToDisconnectFromTheSplitter();
-
     virtual std::set<uint16_t> GetFactors(uint16_t n);
 
     // Get the number of possible products of a factor and another integer
@@ -79,7 +78,7 @@ namespace p2psp {
     Peer_NTS();
     ~Peer_NTS();
     virtual void Init() override;
-
+    virtual void ConnectToTheSplitter() throw(boost::system::system_error) override;
     virtual void SayHello(const ip::udp::endpoint& peer) override;
     virtual void DisconnectFromTheSplitter() override;
     // Handle NTS messages; pass other messages to base class

--- a/src/core/splitter_dbs.cc
+++ b/src/core/splitter_dbs.cc
@@ -143,7 +143,14 @@ namespace p2psp {
     TRACE("Accepted connection from peer "
 	  << incoming_peer);
 #endif
-
+    asio::ip::udp::endpoint incoming_udp_endpoint(incoming_peer.address(),incoming_peer.port());
+    std::vector<char> message;
+    ReceiveMessage(message,incoming_udp_endpoint);
+    std::string s(message.begin(),message.end());
+    if(s=="M"){
+      number_of_monitors_++;
+      TRACE("The number of monitors increased to "<<number_of_monitors_);
+    }
     SendConfiguration(serve_socket);
     //SendTheListOfPeers(serve_socket);
     ReceiveReadyForReceivingChunks(serve_socket);

--- a/src/core/splitter_dbs.cc
+++ b/src/core/splitter_dbs.cc
@@ -144,8 +144,8 @@ namespace p2psp {
 	  << incoming_peer);
 #endif
     asio::ip::udp::endpoint incoming_udp_endpoint(incoming_peer.address(),incoming_peer.port());
-    std::vector<char> message;
-    ReceiveMessage(message,incoming_udp_endpoint);
+	std::vector<char> message;
+    boost::asio::read((*serve_socket),boost::asio::buffer(message));
     std::string s(message.begin(),message.end());
     if(s=="M"){
       number_of_monitors_++;
@@ -265,6 +265,8 @@ namespace p2psp {
     // {{{
 
     // If peer_list_ contains the peer, remove it
+    if(std::find(peer_list_.begin(),peer_list_.begin()+number_of_monitors_,peer)!=peer_list_.begin()+number_of_monitors_)
+      number_of_monitors_--;
     if (find(peer_list_.begin(), peer_list_.end(), peer) != peer_list_.end()) {
       peer_list_.erase(remove(peer_list_.begin(), peer_list_.end(), peer), peer_list_.end());
 

--- a/src/core/splitter_dbs.cc
+++ b/src/core/splitter_dbs.cc
@@ -148,8 +148,15 @@ namespace p2psp {
     boost::asio::read((*serve_socket),boost::asio::buffer(message));
     std::string s(message.begin(),message.end());
     if(s=="M"){
-      number_of_monitors_++;
-      TRACE("The number of monitors increased to "<<number_of_monitors_);
+      if(number_of_monitors_!=1){
+        number_of_monitors_++;
+        TRACE("The number of monitors increased to "<<number_of_monitors_);
+      }
+      else{
+        if(this->peer_list_.size()>=1)
+          number_of_monitors_++;
+        TRACE("The number of monitors increased to "<<number_of_monitors_);
+      }
     }
     SendConfiguration(serve_socket);
     //SendTheListOfPeers(serve_socket);

--- a/src/core/splitter_ems.cc
+++ b/src/core/splitter_ems.cc
@@ -119,6 +119,8 @@ namespace p2psp {
 
 
   void Splitter_EMS::RemovePeer(const ip::udp::endpoint& peer) {
+    if(std::find(peer_list_.begin(),peer_list_.begin()+number_of_monitors_,peer)!=peer_list_.begin()+number_of_monitors_)
+      number_of_monitors_--;
     Splitter_LRS::RemovePeer(peer);
 
     try {

--- a/src/core/splitter_ems.cc
+++ b/src/core/splitter_ems.cc
@@ -179,7 +179,7 @@ namespace p2psp {
     INFO("Sending ID " << peer_id << " to peer " << new_peer);
     serve_socket->send(boost::asio::buffer(peer_id));
     std::unique_lock<std::mutex> lock(arriving_incorporating_peers_mutex_);
-    if (this->peer_list_.size() < (unsigned int) this->number_of_monitors_) {
+    if (this->peer_list_.size() < (unsigned int) this->number_of_monitors_ || sig=='M') {
       // Directly incorporate the monitor peer into the team.
       // The source ports are all set to the same, as the monitor peers
       // should be publicly accessible

--- a/src/core/splitter_ems.cc
+++ b/src/core/splitter_ems.cc
@@ -139,7 +139,7 @@ namespace p2psp {
     boost::asio::ip::tcp::endpoint new_peer_tcp = serve_socket->remote_endpoint();
     boost::asio::ip::udp::endpoint new_peer(new_peer_tcp.address(), new_peer_tcp.port());
     INFO("Accepted connection from peer " << new_peer);
-    boost::array<char, 6> buf;
+    boost::array<char, 7> buf;
     char *raw_data = buf.data();
     boost::asio::ip::address ip_addr;
     int port;
@@ -148,7 +148,7 @@ namespace p2psp {
     in_addr ip_raw = *(in_addr *)(raw_data);
     ip_addr = boost::asio::ip::address::from_string(inet_ntoa(ip_raw));
     port = ntohs(*(short *)(raw_data + 4));
-
+    char sig = ntohs(*(char *)(raw_data+6));
     boost::asio::ip::udp::endpoint peer_local_endpoint_ = boost::asio::ip::udp::endpoint(ip_addr, port);
 
     TRACE("peer local endpoint = (" << peer_local_endpoint_.address().to_string() << ","
@@ -156,6 +156,15 @@ namespace p2psp {
 
     Splitter_EMS::peer_pairs_.emplace(boost::asio::ip::udp::endpoint(new_peer_tcp.address(),
                                                                     new_peer_tcp.port()), peer_local_endpoint_);
+    std::vector<char> message;
+    TRACE("Pre ReceiveMessage");
+    //read((*serve_socket),boost::asio::buffer(message));
+    //std::string s(message.begin(),message.end());
+    std::cout<<"Contents of S "<<sig<<"\n";
+    if(sig==0){
+      number_of_monitors_++;
+      TRACE("The number of monitors increased to "<<number_of_monitors_);
+    }
     this->SendConfiguration(serve_socket);
 
     // Send the generated ID to peer

--- a/src/core/splitter_ems.cc
+++ b/src/core/splitter_ems.cc
@@ -148,7 +148,7 @@ namespace p2psp {
     in_addr ip_raw = *(in_addr *)(raw_data);
     ip_addr = boost::asio::ip::address::from_string(inet_ntoa(ip_raw));
     port = ntohs(*(short *)(raw_data + 4));
-    char sig = ntohs(*(char *)(raw_data+6));
+    char sig = *(raw_data+6);
     boost::asio::ip::udp::endpoint peer_local_endpoint_ = boost::asio::ip::udp::endpoint(ip_addr, port);
 
     TRACE("peer local endpoint = (" << peer_local_endpoint_.address().to_string() << ","
@@ -156,14 +156,19 @@ namespace p2psp {
 
     Splitter_EMS::peer_pairs_.emplace(boost::asio::ip::udp::endpoint(new_peer_tcp.address(),
                                                                     new_peer_tcp.port()), peer_local_endpoint_);
-    std::vector<char> message;
-    TRACE("Pre ReceiveMessage");
     //read((*serve_socket),boost::asio::buffer(message));
     //std::string s(message.begin(),message.end());
-    std::cout<<"Contents of S "<<sig<<"\n";
-    if(sig==0){
-      number_of_monitors_++;
-      TRACE("The number of monitors increased to "<<number_of_monitors_);
+    TRACE("Contents of Signalling message: "<<sig);
+    if(sig=='M'){
+      if(number_of_monitors_!=1){
+        number_of_monitors_++;
+        TRACE("The number of monitors increased to "<<number_of_monitors_);
+      }
+      else{
+        if(this->peer_list_.size()>=1)
+          number_of_monitors_++;
+        TRACE("The number of monitors increased to "<<number_of_monitors_);
+      }
     }
     this->SendConfiguration(serve_socket);
 

--- a/src/core/splitter_nts.cc
+++ b/src/core/splitter_nts.cc
@@ -379,7 +379,7 @@ namespace p2psp {
     ip::udp::endpoint new_peer(new_peer_tcp.address(), new_peer_tcp.port());
     INFO("Accepted connection from peer " << new_peer);
     std::vector<char> message;
-    ReceiveMessage(message,new_peer);
+    boost::asio::read((*serve_socket),boost::asio::buffer(message));
     std::string s(message.begin(),message.end());
     if(s=="M"){
       number_of_monitors_++;
@@ -653,7 +653,8 @@ namespace p2psp {
 
   void Splitter_NTS::RemovePeer(const ip::udp::endpoint& peer) {
     // {{{
-
+    if(std::find(peer_list_.begin(),peer_list_.begin()+number_of_monitors_,peer)!=peer_list_.begin()+number_of_monitors_)
+      number_of_monitors_--;
     Splitter_LRS/*_DBS*/::RemovePeer(peer);
 
     try {

--- a/src/core/splitter_nts.cc
+++ b/src/core/splitter_nts.cc
@@ -378,6 +378,13 @@ namespace p2psp {
     ip::tcp::endpoint new_peer_tcp = serve_socket->remote_endpoint();
     ip::udp::endpoint new_peer(new_peer_tcp.address(), new_peer_tcp.port());
     INFO("Accepted connection from peer " << new_peer);
+    std::vector<char> message;
+    ReceiveMessage(message,new_peer);
+    std::string s(message.begin(),message.end());
+    if(s=="M"){
+      number_of_monitors_++;
+      TRACE("The number of monitors increased to "<<number_of_monitors_);
+    }
     this->SendConfiguration(serve_socket);
     // Send the generated ID to peer
     std::string peer_id = this->GenerateId();
@@ -402,6 +409,30 @@ namespace p2psp {
       // Splitter will continue with IncorporatePeer() as soon as the
       // arriving peer has sent UDP packets to splitter and monitor
     }
+
+    // }}}
+  }
+  void Splitter_NTS::InsertPeer(const boost::asio::ip::udp::endpoint &peer)
+  {
+    Splitter_DBS::InsertPeer(peer);
+  }
+  void Splitter_NTS::InsertPeer(const boost::asio::ip::udp::endpoint &peer,char sig)
+  {
+    // {{{
+    if (find(peer_list_.begin(), peer_list_.end(), peer) != peer_list_.end()) {
+      peer_list_.erase(find(peer_list_.begin(), peer_list_.end(), peer));
+    }
+    if(sig=='M'){
+      peer_list_.insert(peer_list_.begin(),peer);
+    }
+    else{
+    peer_list_.push_back(peer);
+    }
+    losses_[peer] = 0;
+#if defined __D_CHURN__
+    TRACE("Inserted peer "
+    << peer);
+#endif
 
     // }}}
   }

--- a/src/core/splitter_nts.h
+++ b/src/core/splitter_nts.h
@@ -134,7 +134,8 @@ namespace p2psp {
     // The thread listens to this->extra_socket_ to determine the currently
     // allocated source port of incorporated peers behind SYMSP NATs
     virtual void ListenExtraSocketThread();
-
+    virtual void InsertPeer(const boost::asio::ip::udp::endpoint &peer);
+    virtual void InsertPeer(const boost::asio::ip::udp::endpoint &peer, char sig);
     virtual void IncorporatePeer(const std::string& peer_id);
     virtual void SendNewPeer(const std::string& peer_id,
 			     const boost::asio::ip::udp::endpoint& new_peer,


### PR DESCRIPTION
This small change in the code lets the P2PSP team handle the arrival of monitors dynamically. The number of monitors need not be set while creating the team. 

This allows monitor peers to connect to the splitter on the go.
Modified layers
- DBS
- NTS
- EMS