### PR TITLE
added Boost download, compilation before using it

### DIFF
--- a/make.py
+++ b/make.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import os
 import sys
 import shutil
+import tarfile
 import platform
 import subprocess
 import multiprocessing
@@ -14,6 +15,28 @@ only_cmake = False
 build_debug = False
 cmake = 'cmake'
 make = 'make'
+
+''' replace the url with updated link if any'''
+url = 'https://netix.dl.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2'
+
+print("downloading boost libraries")
+os.system("wget -O boost_1_63_0.tar.bz2 " + url)
+
+''' extracts the downloaded boost libraries'''
+def untar(filename):
+    if (filename.endswith("tar.bz2")):
+        tar = tarfile.open(filename)
+        print("Extracting the files...")
+        tar.extractall()
+        tar.close()
+        print("Successfully extracted in Current Directory")
+    else:
+        print("Not a tar.gz file")
+
+untar("boost_1_63_0.tar.bz2")
+
+'''Installing the boost libraries to a seperate directory '''
+os.system("cd boost_1_63_0 && ./bootstrap.sh --prefix=boost_lib && ./b2 install")
 
 if len(sys.argv) >= 2:
     if sys.argv[1] == '-h':
@@ -57,8 +80,9 @@ if sys_name == 'Linux' or sys_name == 'Darwin':
         print('Building for Debug...\n')
     else:
         print('Building for Release...\n')
-
-    command = 'cd build && ' + cmake + ' .. && echo'
+        
+    ''' below command sets the manually installed libraries rather than the system libraries'''
+    command = 'cd build && cmake -DBOOST_NO_SYSTEM_PATHS=TRUE -DBOOST_ROOT="boost_1_63_0" -DBOOST_INCLUDEDIR="boost_1_63_0/boost_lib/include" -DBOOST_LIBRARYDIR="boost_1_63_0/boost_lib/lib" ..'
     if os.system(command) == 0:
         command = 'cd build && make -j' + str(number_of_cores)
         if not only_cmake:

--- a/make.py
+++ b/make.py
@@ -8,7 +8,7 @@ import tarfile
 import platform
 import subprocess
 import multiprocessing
-
+import os.path
 bin_dir = 'bin'
 build_dir = 'build'
 only_cmake = False
@@ -16,27 +16,33 @@ build_debug = False
 cmake = 'cmake'
 make = 'make'
 
-''' replace the url with updated link if any'''
-url = 'https://netix.dl.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2'
+'''replace with the new version if any'''
+boost = "boost_1_63_0.tar.bz2"
 
-print("downloading boost libraries")
-os.system("wget -O boost_1_63_0.tar.bz2 " + url)
+print('Enter yes if you want to download the boost libraries and use the updated boost libraries...')
+user_input = raw_input()
+    
 
-''' extracts the downloaded boost libraries'''
-def untar(filename):
-    if (filename.endswith("tar.bz2")):
-        tar = tarfile.open(filename)
-        print("Extracting the files...")
-        tar.extractall()
-        tar.close()
-        print("Successfully extracted in Current Directory")
-    else:
-        print("Not a tar.gz file")
+if os.path.isfile(boost) == False:
+    if user_input == "yes":
+        ''' replace the url with updated link if any'''
+        url = 'https://netix.dl.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.bz2'
+        print("\ndownloading boost libraries")
+        os.system("wget --no-check-certificate -O boost_1_63_0.tar.bz2 " + url)
+        ''' extracts the downloaded boost libraries'''
+        def untar(filename):
+            if (filename.endswith("tar.bz2")):
+                tar = tarfile.open(filename)
+                print("Extracting the files...")
+                tar.extractall()
+                tar.close()
+                print("Successfully extracted in Current Directory")
 
-untar("boost_1_63_0.tar.bz2")
+        untar(boost)
 
-'''Installing the boost libraries to a seperate directory '''
-os.system("cd boost_1_63_0 && ./bootstrap.sh --prefix=boost_lib && ./b2 install")
+        print('Compiling and Installing the boost libraries to a seperate directory...')
+        '''Installing the boost libraries to a seperate directory '''
+        os.system("cd boost_1_63_0 && ./bootstrap.sh --prefix=boost_lib && ./b2 install")
 
 if len(sys.argv) >= 2:
     if sys.argv[1] == '-h':
@@ -72,6 +78,8 @@ if not os.path.exists(build_dir):
 sys_name = platform.system()
 
 if sys_name == 'Linux' or sys_name == 'Darwin':
+    if user_input != "yes":
+        print('\nproceeding with the system libraries')
     print('\nMaking for Linux...')
     number_of_cores = multiprocessing.cpu_count()
     print('Number of cores = ' + str(number_of_cores) + '\n')
@@ -80,9 +88,11 @@ if sys_name == 'Linux' or sys_name == 'Darwin':
         print('Building for Debug...\n')
     else:
         print('Building for Release...\n')
-        
     ''' below command sets the manually installed libraries rather than the system libraries'''
-    command = 'cd build && cmake -DBOOST_NO_SYSTEM_PATHS=TRUE -DBOOST_ROOT="boost_1_63_0" -DBOOST_INCLUDEDIR="boost_1_63_0/boost_lib/include" -DBOOST_LIBRARYDIR="boost_1_63_0/boost_lib/lib" ..'
+    if user_input == "yes":
+        command = 'cd build && cmake -DBOOST_NO_SYSTEM_PATHS=TRUE -DBOOST_ROOT="boost_1_63_0" -DBOOST_INCLUDEDIR="boost_1_63_0/boost_lib/include" -DBOOST_LIBRARYDIR="boost_1_63_0/boost_lib/lib" ..'
+    else:
+        command = 'cd build && ' + cmake + ' .. && echo'
     if os.system(command) == 0:
         command = 'cd build && make -j' + str(number_of_cores)
         if not only_cmake:


### PR DESCRIPTION
@vicente-gonzalez-ruiz I automated the download and compilation process as you suggested and user can use the new downloaded Boost libraries rather than system libraries. The compilation runs fine, but I get some `CMake` warnings([link](http://pastebin.com/iGkbKZJU)). I think the reason why we get these warnings is because system has old libraries.Apart from that all the automation works fine.